### PR TITLE
Add flake8 check to Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ python:
 install: "pip install -r requirements.txt"
 # command to run tests
 script: python test.py
-# use new travis-ci container-based infrastructure 
+# use new travis-ci container-based infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: python
 python:
     - "2.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements.txt flake8"
 # command to run tests
-script: python test.py
+script:
+    - flake8 jenkins_exporter.py --max-line-length=140
+    - python test.py
 # use new travis-ci container-based infrastructure
 sudo: false


### PR DESCRIPTION
Hello!

This is a PR to add automatic `flake8` checking to Travis builds. Right now I set an arbitrarily long line-length limit (140) to make sure flake8 passes, but I'd like to know what the maintainers think a good line length should be. My vote would be 90 characters, but 80 is the default.

If this PR goes through, I can work on a subsequent one to make this fit into the line-length the maintainers pick. Thanks!