### PR TITLE
feat: make it easier to identify multibranch jobs

### DIFF
--- a/jenkins_exporter.py
+++ b/jenkins_exporter.py
@@ -32,7 +32,7 @@ class JenkinsCollector(object):
         self._setup_empty_prometheus_metrics()
 
         for job in jobs:
-            name = job['name']
+            name = job['fullName']
             if DEBUG:
                 print "Found Job: %s" % name
                 pprint(job)
@@ -45,9 +45,9 @@ class JenkinsCollector(object):
     def _request_data(self):
         # Request exactly the information we need from Jenkins
         url = '{0}/api/json'.format(self._target)
-        jobs = "[number,timestamp,duration,actions[queuingDurationMillis,totalDurationMillis," \
+        jobs = "[fullName,number,timestamp,duration,actions[queuingDurationMillis,totalDurationMillis," \
                "skipCount,failCount,totalCount,passCount]]"
-        tree = 'jobs[name,url,{0}]'.format(','.join([s + jobs for s in self.statuses]))
+        tree = 'jobs[fullName,url,{0}]'.format(','.join([s + jobs for s in self.statuses]))
         params = {
             'tree': tree,
         }


### PR DESCRIPTION
Using the `name`  makes it difficult to identify multibranch jobs:
```
jenkins_job_last_build_total_duration_seconds{jobname="PR-4"} 192.255
jenkins_job_last_build_total_duration_seconds{jobname="master"} 197.974
jenkins_job_last_build_total_duration_seconds{jobname="job-generator"} 1.205
jenkins_job_last_build_total_duration_seconds{jobname="master"} 16.982
```
I'm not sure which repo 👆 jobs belong to.

Using the `fullName` makes it easier to identify multibranch jobs:
```
jenkins_job_last_build_total_duration_seconds{jobname="local-test-sqs/PR-4"} 192.255
jenkins_job_last_build_total_duration_seconds{jobname="local-test-sqs/master"} 197.974
jenkins_job_last_build_total_duration_seconds{jobname="job-generator"} 1.205
jenkins_job_last_build_total_duration_seconds{jobname="stories/master"} 16.982
```