### PR TITLE
Arguments to CMD in exec form must not contain single quotes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,3 @@ EXPOSE 9118
 ENV JENKINS_SERVER=http://jenkins:8080 VIRTUAL_PORT=9118 DEBUG=0
 
 ENTRYPOINT [ "python", "-u", "./jenkins_exporter.py" ]
-CMD []


### PR DESCRIPTION
Better to remove CMD at all, to avoid issues with docker linter `ERROR: Arguments to CMD in exec form must not contain single quotes on line 15`.