### PR TITLE
raise exception for non-200 jenkins api status

### DIFF
--- a/jenkins_exporter.py
+++ b/jenkins_exporter.py
@@ -56,7 +56,7 @@ class JenkinsCollector(object):
             # params = tree: jobs[name,lastBuild[number,timestamp,duration,actions[queuingDurationMillis...
             response = requests.get(myurl, params=params, auth=(self._user, self._password))
             if response.status_code != requests.codes.ok:
-                return[]
+                raise Exception("Call to url %s failed with status: %s" % (myurl, response.status_code))
             result = response.json()
             if DEBUG:
                 pprint(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prometheus-client==0.0.13
+prometheus-client==0.1.0
 requests==2.10.0


### PR DESCRIPTION
Currently, the exporter is silent when the jenkins url returns an unsuccessful status. This especially makes debugging invalid auth difficult. This change raises an exception instead. In order for the exception to be handled, I had to update the prometheus client to the latest version. Otherwise, the http endpoint continues to return a 200.