### PR TITLE
Add matrix project job support.

### DIFF
--- a/jenkins_exporter.py
+++ b/jenkins_exporter.py
@@ -80,7 +80,7 @@ class JenkinsCollector(object):
             if DEBUG:
                 pprint(response.text)
             if response.status_code != requests.codes.ok:
-                raise Exception("Call to url %s failed with status: %s" % (myurl, response.status_code))
+                return []
             result = response.json()
             if DEBUG:
                 pprint(result)


### PR DESCRIPTION
matrix project jobs will be appeared as new metrics with label format jobname=_jobname_/_configuration_

for example:
```
jenkins_job_last_stable_build_duration_seconds{jobname="dummy_multi_conf"} 8.037
jenkins_job_last_stable_build_duration_seconds{jobname="dummy_multi_conf/branch=7.8"} 1.08
jenkins_job_last_stable_build_duration_seconds{jobname="dummy_multi_conf/branch=7.8.1"} 1.08
jenkins_job_last_stable_build_duration_seconds{jobname="dummy_multi_conf/branch=7.8.2"} 2.694
jenkins_job_last_stable_build_duration_seconds{jobname="dummy_multi_conf/branch=8.0"} 1.077
```

![image](https://user-images.githubusercontent.com/3967080/49281414-92848000-f49d-11e8-9c19-ad20199d9d9c.png)
